### PR TITLE
Update nb_NO.lang

### DIFF
--- a/src/main/resources/assets/sync/lang/nb_NO.lang
+++ b/src/main/resources/assets/sync/lang/nb_NO.lang
@@ -1,6 +1,6 @@
 sync.breakShellUnit=%1$s ødelagte et av skallene til %2$s
 item.Sync_ShellConstructor.name=Skall Maskin
-item.Sync_ShellStorage.name=Skal Lager
+item.Sync_ShellStorage.name=Skall Lager
 item.Sync_Treadmill.name=Tredemølle
 item.Sync_SyncCore.name=Synkroniserings kjerne
 death.attack.syncFail=%1$s synkroniserte inn i et dødt skall


### PR DESCRIPTION
Fixed spelling of "skal" (shall) to "skall" (shell). 
I'm still a bit puzzled about how best to translate:
The names of the shell constructor and the shell storage, as well as whether they should be compounded as a single word or as two words.

The verb "to morph" as I've never seen it before and cannot find any variant in any Norwegian dictionary I own (for any major dialect). I have a sneaking suspicion that that the base verb of a neologistic loan word would be morfere (and hence "morfert" there), but I'm waiting on answers from friends before making those changes.

Additionally, there's an unusual overlap of the words for "make" (å lage, å skape) and cupboard/storage (en lager/et skap) which I would like to avoid both of these words. I'm considering "bygger" (literally "builder" without the context of being a person who builds, but not a word I've seen) for constructor. As for the storage, I'm considering "holder" (which means roughly the same as its English equivalent).
Shall get back to this after talking to friends about the idea of a "skallbygger" and a "skallholder".
