### PR TITLE
Small cleanup, fix bugs and add The One Probe integration

### DIFF
--- a/src/main/java/me/ichun/mods/sync/client/HUDHandlerTheOneProbe.java
+++ b/src/main/java/me/ichun/mods/sync/client/HUDHandlerTheOneProbe.java
@@ -1,0 +1,65 @@
+package me.ichun.mods.sync.client;
+
+import com.google.common.base.Function;
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.IProbeInfoProvider;
+import mcjty.theoneprobe.api.ITheOneProbe;
+import mcjty.theoneprobe.api.ProbeMode;
+import mcjty.theoneprobe.apiimpl.styles.ProgressStyle;
+import me.ichun.mods.sync.common.Sync;
+import me.ichun.mods.sync.common.tileentity.TileEntityShellConstructor;
+import me.ichun.mods.sync.common.tileentity.TileEntityShellStorage;
+import me.ichun.mods.sync.common.tileentity.TileEntityTreadmill;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.translation.I18n;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
+import java.text.DecimalFormat;
+
+public class HUDHandlerTheOneProbe implements Function<ITheOneProbe, Void>, IProbeInfoProvider {
+    private static final ProgressStyle STYLE_BUILD_PROGRESS = new ProgressStyle().showText(true).prefix(I18n.translateToLocal("sync.waila.progress") + ": ").suffix("%");
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("##.##");
+
+    @Nullable
+    @Override
+    public Void apply(@Nullable ITheOneProbe input) {
+        if (input == null) {
+            Sync.LOGGER.error("Could not load The One Probe Compat!");
+            return null;
+        }
+        Sync.LOGGER.info("Loading The One Probe compat");
+        input.registerProvider(this);
+        return null;
+    }
+
+    @Override
+    public String getID() {
+        return Sync.MOD_ID;
+    }
+
+    @Override
+    public void addProbeInfo(ProbeMode probeMode, IProbeInfo info, EntityPlayer entityPlayer, World world, IBlockState iBlockState, IProbeHitData iProbeHitData) {
+        if (iBlockState.getBlock() == Sync.blockDualVertical) {
+            TileEntity tileEntity = world.getTileEntity(iProbeHitData.getPos());
+            if (tileEntity instanceof TileEntityShellConstructor) {
+                TileEntityShellConstructor te = (TileEntityShellConstructor) tileEntity;
+                info.text(I18n.translateToLocal("sync.waila.owner") + ": " + (te.getPlayerName().equals("") ? "None" : te.getPlayerName()));
+                info.progress((int) Math.ceil(te.getBuildProgress() / Sync.config.shellConstructionPowerRequirement * 100), 100, STYLE_BUILD_PROGRESS);
+            }
+            else if (tileEntity instanceof TileEntityShellStorage) {
+                TileEntityShellStorage te = (TileEntityShellStorage) tileEntity;
+                info.text(I18n.translateToLocal("sync.waila.owner") + ": " + (te.getPlayerName().equals("") ? "None" : te.getPlayerName()));
+                info.text(I18n.translateToLocal("sync.waila.active") + ": " + (te.isPowered() ? I18n.translateToLocal("gui.yes") : I18n.translateToLocal("gui.no")));
+            }
+            else if (tileEntity instanceof TileEntityTreadmill) {
+                TileEntityTreadmill te = (TileEntityTreadmill) tileEntity;
+                info.text(I18n.translateToLocal("sync.waila.entity") + ": " + (te.latchedEnt != null ? te.latchedEnt.getName() : "None"));
+                info.text(I18n.translateToLocal("sync.waila.powerout") + ": " + DECIMAL_FORMAT.format(te.powerOutput()) + "PW");
+            }
+        }
+    }
+}

--- a/src/main/java/me/ichun/mods/sync/client/HUDHandlerWaila.java
+++ b/src/main/java/me/ichun/mods/sync/client/HUDHandlerWaila.java
@@ -26,7 +26,7 @@ import net.minecraft.world.World;
 import java.text.DecimalFormat;
 import java.util.List;
 
-public class HUDHandlerSync implements IWailaDataProvider {
+public class HUDHandlerWaila implements IWailaDataProvider {
 
     @Override
     public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
@@ -73,7 +73,7 @@ public class HUDHandlerSync implements IWailaDataProvider {
     }
 
     public static void callbackRegister(IWailaRegistrar registrar) {
-        registrar.registerBodyProvider(new HUDHandlerSync(), BlockDualVertical.class);
+        registrar.registerBodyProvider(new HUDHandlerWaila(), BlockDualVertical.class);
 
         registrar.addConfig("Sync", "sync.showowner", I18n.translateToLocal("sync.waila.showowner"));
         registrar.addConfig("Sync", "sync.showprogress", I18n.translateToLocal("sync.waila.showprogress"));

--- a/src/main/java/me/ichun/mods/sync/client/core/EventHandlerClient.java
+++ b/src/main/java/me/ichun/mods/sync/client/core/EventHandlerClient.java
@@ -729,13 +729,12 @@ public class EventHandlerClient
 
                     Tessellator tessellator = Tessellator.getInstance();
                     VertexBuffer buffer = tessellator.getBuffer();
-                    buffer.color(240, 240, 240, 255);
+                    buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
 
-                    buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
-                    buffer.pos(pX, pY + size, 0.0D).tex( 0.0D, 0.999D);
-                    buffer.pos(pX + size, pY + size, 0.0D).tex( 1.0D, 0.999D);
-                    buffer.pos(pX + size, pY, 0.0D).tex( 1.0D, 0.0D);
-                    buffer.pos(pX, pY, 0.0D).tex( 0.0D, 0.0D);
+                    buffer.pos(pX, pY + size, 0.0D).tex( 0.0D, 0.999D).color(240, 240, 240, 255).endVertex();
+                    buffer.pos(pX + size, pY + size, 0.0D).tex( 1.0D, 0.999D).color(240, 240, 240, 255).endVertex();
+                    buffer.pos(pX + size, pY, 0.0D).tex( 1.0D, 0.0D).color(240, 240, 240, 255).endVertex();
+                    buffer.pos(pX, pY, 0.0D).tex( 0.0D, 0.0D).color(240, 240, 240, 255).endVertex();
                     tessellator.draw();
                 }
             }

--- a/src/main/java/me/ichun/mods/sync/client/core/ProxyClient.java
+++ b/src/main/java/me/ichun/mods/sync/client/core/ProxyClient.java
@@ -50,7 +50,7 @@ public class ProxyClient extends ProxyCommon
 		registerItemWithTESR(Sync.itemShellConstructor, RenderItemShellConstructor.ItemShellConstructorRenderHack.class, new RenderItemShellConstructor());
 		registerItemWithTESR(Sync.itemShellStorage, RenderItemShellStorage.ItemShellStorageRenderHack.class, new RenderItemShellStorage());
 		registerItemWithTESR(Sync.itemTreadmill, RenderItemTreadmill.ItemTreadmillRenderHack.class, new RenderItemTreadmill());
-		ModelLoader.setCustomModelResourceLocation(Sync.itemPlaceholder, 0, new ModelResourceLocation("sync:item_sync_core", "inventory"));
+		ModelLoader.setCustomModelResourceLocation(Sync.itemSyncCore, 0, new ModelResourceLocation("sync:item_sync_core", "inventory"));
 	}
 
 	//TODO remove all this hacks, use a static fromat

--- a/src/main/java/me/ichun/mods/sync/client/model/ModelShellConstructor.java
+++ b/src/main/java/me/ichun/mods/sync/client/model/ModelShellConstructor.java
@@ -54,7 +54,7 @@ public class ModelShellConstructor extends ModelBase
 	public ArrayList<int[]> armPixelCoords;
 	public ArrayList<int[]> headPixelCoords;
 	
-	public ModelPlayer modelBiped;
+	public ModelPlayer modelPlayer;
 	
 	public ResourceLocation txBiped;
 
@@ -92,8 +92,8 @@ public class ModelShellConstructor extends ModelBase
 			}
 		}
 
-		modelBiped = new ModelPlayer(1F, false);
-		modelBiped.isChild = false;
+		modelPlayer = new ModelPlayer(1F, false);
+		modelPlayer.isChild = false;
 		
 		txBiped = DefaultPlayerSkin.getDefaultSkinLegacy();
 		
@@ -589,13 +589,13 @@ public class ModelShellConstructor extends ModelBase
 					
 					GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 	
-					modelBiped.bipedHead.render(f5);
-                    modelBiped.bipedHeadwear.render(f5);
-					modelBiped.bipedBody.render(f5);
-					modelBiped.bipedRightArm.render(f5);
-					modelBiped.bipedLeftArm.render(f5);
-					modelBiped.bipedRightLeg.render(f5);
-					modelBiped.bipedLeftLeg.render(f5);
+					modelPlayer.bipedHead.render(f5);
+                    modelPlayer.bipedHeadwear.render(f5);
+					modelPlayer.bipedBody.render(f5);
+					modelPlayer.bipedRightArm.render(f5);
+					modelPlayer.bipedLeftArm.render(f5);
+					modelPlayer.bipedRightLeg.render(f5);
+					modelPlayer.bipedLeftLeg.render(f5);
 					
 					GL11.glStencilFunc(GL11.GL_ALWAYS, stencilMask, stencilMask);
 					
@@ -619,13 +619,13 @@ public class ModelShellConstructor extends ModelBase
 					
 					if(prog < 1.0F)
 					{
-						modelBiped.bipedHead.render(f5);
-                        modelBiped.bipedHeadwear.render(f5);
-						modelBiped.bipedBody.render(f5);
-						modelBiped.bipedRightArm.render(f5);
-						modelBiped.bipedLeftArm.render(f5);
-						modelBiped.bipedRightLeg.render(f5);
-						modelBiped.bipedLeftLeg.render(f5);
+						modelPlayer.bipedHead.render(f5);
+                        modelPlayer.bipedHeadwear.render(f5);
+						modelPlayer.bipedBody.render(f5);
+						modelPlayer.bipedRightArm.render(f5);
+						modelPlayer.bipedLeftArm.render(f5);
+						modelPlayer.bipedRightLeg.render(f5);
+						modelPlayer.bipedLeftLeg.render(f5);
 					}
 					
 					GL11.glDepthMask(false);
@@ -639,13 +639,13 @@ public class ModelShellConstructor extends ModelBase
 					
 					GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 	
-					modelBiped.bipedHead.render(f5);
-                    modelBiped.bipedHeadwear.render(f5);
-					modelBiped.bipedBody.render(f5);
-					modelBiped.bipedRightArm.render(f5);
-					modelBiped.bipedLeftArm.render(f5);
-					modelBiped.bipedRightLeg.render(f5);
-					modelBiped.bipedLeftLeg.render(f5);
+					modelPlayer.bipedHead.render(f5);
+                    modelPlayer.bipedHeadwear.render(f5);
+					modelPlayer.bipedBody.render(f5);
+					modelPlayer.bipedRightArm.render(f5);
+					modelPlayer.bipedLeftArm.render(f5);
+					modelPlayer.bipedRightLeg.render(f5);
+					modelPlayer.bipedLeftLeg.render(f5);
 					
 					GL11.glStencilFunc(GL11.GL_ALWAYS, 0, stencilMask);
 					
@@ -673,13 +673,13 @@ public class ModelShellConstructor extends ModelBase
 					GlStateManager.translate(0.0D, -0.00005D, 0.0D);
 					GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 					
-					modelBiped.bipedHead.render(f5);
-                    modelBiped.bipedHeadwear.render(f5);
-					modelBiped.bipedBody.render(f5);
-					modelBiped.bipedRightArm.render(f5);
-					modelBiped.bipedLeftArm.render(f5);
-					modelBiped.bipedRightLeg.render(f5);
-					modelBiped.bipedLeftLeg.render(f5);
+					modelPlayer.bipedHead.render(f5);
+                    modelPlayer.bipedHeadwear.render(f5);
+					modelPlayer.bipedBody.render(f5);
+					modelPlayer.bipedRightArm.render(f5);
+					modelPlayer.bipedLeftArm.render(f5);
+					modelPlayer.bipedRightLeg.render(f5);
+					modelPlayer.bipedLeftLeg.render(f5);
 	
 					GL11.glStencilMask(0);
 					GL11.glDisable(GL11.GL_STENCIL_TEST);
@@ -688,13 +688,13 @@ public class ModelShellConstructor extends ModelBase
 				{
 					if(prog < 1.0F)
 					{
-						modelBiped.bipedHead.render(f5);
-                        modelBiped.bipedHeadwear.render(f5);
-						modelBiped.bipedBody.render(f5);
-						modelBiped.bipedRightArm.render(f5);
-						modelBiped.bipedLeftArm.render(f5);
-						modelBiped.bipedRightLeg.render(f5);
-						modelBiped.bipedLeftLeg.render(f5);
+						modelPlayer.bipedHead.render(f5);
+                        modelPlayer.bipedHeadwear.render(f5);
+						modelPlayer.bipedBody.render(f5);
+						modelPlayer.bipedRightArm.render(f5);
+						modelPlayer.bipedLeftArm.render(f5);
+						modelPlayer.bipedRightLeg.render(f5);
+						modelPlayer.bipedLeftLeg.render(f5);
 					}
 	
 					GlStateManager.enableTexture2D();
@@ -704,13 +704,15 @@ public class ModelShellConstructor extends ModelBase
 					GlStateManager.translate(0.0D, -0.00005D, 0.0D);
 					GlStateManager.color(1.0F, 1.0F, 1.0F, (prog - 0.95F) / 0.05F);
 					
-					modelBiped.bipedHead.render(f5);
-                    modelBiped.bipedHeadwear.render(f5);
-					modelBiped.bipedBody.render(f5);
-					modelBiped.bipedRightArm.render(f5);
-					modelBiped.bipedLeftArm.render(f5);
-					modelBiped.bipedRightLeg.render(f5);
-					modelBiped.bipedLeftLeg.render(f5);
+					modelPlayer.bipedHead.render(f5);
+                    modelPlayer.bipedHeadwear.render(f5);
+					modelPlayer.bipedBody.render(f5);
+					GlStateManager.translate(0F, 0F, 0.001F);
+					modelPlayer.bipedRightArm.render(f5);
+					modelPlayer.bipedLeftArm.render(f5);
+					modelPlayer.bipedRightLeg.render(f5);
+					GlStateManager.translate(0F, 0F, 0.001F);
+					modelPlayer.bipedLeftLeg.render(f5);
 				}
 				
 				MinecraftForgeClient.releaseStencilBit(stencilBit);

--- a/src/main/java/me/ichun/mods/sync/client/render/TileRendererDualVertical.java
+++ b/src/main/java/me/ichun/mods/sync/client/render/TileRendererDualVertical.java
@@ -189,13 +189,12 @@ public class TileRendererDualVertical extends TileEntitySpecialRenderer<TileEnti
 					byte b0 = 0;
 					GlStateManager.disableTexture2D();
 					VertexBuffer buffer = tessellator.getBuffer();
-					buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
+					buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
 					int j = fontrenderer.getStringWidth(ss.getName()) / 2;
-					buffer.color(0.0F, 0.0F, 0.0F, 0.25F);
-					buffer.pos((double)(-j - 1), (double)(-1 + b0), 0.0D);
-					buffer.pos((double)(-j - 1), (double)(8 + b0), 0.0D);
-					buffer.pos((double)(j + 1), (double)(8 + b0), 0.0D);
-					buffer.pos((double)(j + 1), (double)(-1 + b0), 0.0D);
+					buffer.pos((double)(-j - 1), (double)(-1 + b0), 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+					buffer.pos((double)(-j - 1), (double)(8 + b0), 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+					buffer.pos((double)(j + 1), (double)(8 + b0), 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+					buffer.pos((double)(j + 1), (double)(-1 + b0), 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
 					tessellator.draw();
 					GlStateManager.enableTexture2D();
 					GlStateManager.enableDepth();

--- a/src/main/java/me/ichun/mods/sync/common/Sync.java
+++ b/src/main/java/me/ichun/mods/sync/common/Sync.java
@@ -69,7 +69,7 @@ public class Sync
     public static PacketChannel channel;
     public static Item itemShellConstructor, itemShellStorage, itemTreadmill;
 
-    public static Item itemPlaceholder;
+    public static Item itemSyncCore;
 
     @EventHandler
     public void preLoad(FMLPreInitializationEvent event)
@@ -164,27 +164,14 @@ public class Sync
             if(recipes.get(i) instanceof ShapedRecipes)
             {
                 ShapedRecipes recipe = (ShapedRecipes)recipes.get(i);
-                if(recipe.getRecipeOutput().isItemEqual(new ItemStack(Sync.itemPlaceholder)))
+                if(recipe.getRecipeOutput().isItemEqual(new ItemStack(Sync.itemSyncCore)))
                 {
                     recipes.remove(i);
                 }
             }
         }
 
-        GameRegistry.addRecipe(new ItemStack(Sync.itemPlaceholder),
+        GameRegistry.addRecipe(new ItemStack(Sync.itemSyncCore),
                 "DLD", "QEQ", "MRM", 'D', Blocks.DAYLIGHT_DETECTOR, 'L', Blocks.LAPIS_BLOCK, 'Q', Items.QUARTZ, 'E', ((Sync.config.hardcoreMode == 1 || Sync.config.hardcoreMode == 2 && DimensionManager.getWorld(0).getWorldInfo().isHardcoreModeEnabled()) ? Blocks.BEACON : Items.ENDER_PEARL), 'M', Items.EMERALD, 'R', Blocks.REDSTONE_BLOCK);
-    }
-
-    public static boolean alwaysFalse(IBlockState state1, IBlockState state2) {
-        if (state2.getBlock() instanceof BlockDualVertical || state1.getBlock() instanceof BlockDualVertical) {
-            if (!(state1.getBlock() instanceof BlockDualVertical) || !(state2.getBlock() instanceof BlockDualVertical)) {
-                System.out.println("Wrong BlockState, BREAK");
-                return true;
-            }
-        }
-        if (state1.getBlock() instanceof BlockDualVertical) {
-            System.out.println("State 1 " + state1.getValue(BlockDualVertical.TYPE) + " State 2 " + state2.getValue(BlockDualVertical.TYPE));
-        }
-        return false;
     }
 }

--- a/src/main/java/me/ichun/mods/sync/common/Sync.java
+++ b/src/main/java/me/ichun/mods/sync/common/Sync.java
@@ -5,11 +5,9 @@ import me.ichun.mods.ichunutil.common.core.network.PacketChannel;
 import me.ichun.mods.ichunutil.common.iChunUtil;
 import me.ichun.mods.ichunutil.common.module.update.UpdateChecker;
 import me.ichun.mods.sync.client.core.EventHandlerClient;
-import me.ichun.mods.sync.common.block.BlockDualVertical;
 import me.ichun.mods.sync.common.core.*;
 import me.ichun.mods.sync.common.shell.ShellHandler;
 import net.minecraft.block.Block;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.passive.EntityPig;
 import net.minecraft.entity.passive.EntityWolf;
@@ -38,7 +36,7 @@ import java.util.List;
 @Mod(modid = Sync.MOD_ID, name = Sync.MOD_NAME,
         version = Sync.VERSION,
         guiFactory = "me.ichun.mods.ichunutil.common.core.config.GenericModGuiFactory",
-        dependencies = "required-after:ichunutil@[" + iChunUtil.VERSION_MAJOR + ".4.0," + (iChunUtil.VERSION_MAJOR + 1) + ".0.0);after:CoFHCore;after:Waila",
+        dependencies = "required-after:ichunutil@[" + iChunUtil.VERSION_MAJOR + ".4.0," + (iChunUtil.VERSION_MAJOR + 1) + ".0.0);after:Waila",
         acceptableRemoteVersions = "[" + iChunUtil.VERSION_MAJOR +".0.0," + iChunUtil.VERSION_MAJOR + ".1.0)"
 )
 public class Sync
@@ -92,7 +90,8 @@ public class Sync
 
         FMLInterModComms.sendMessage("AppliedEnergistics", "movabletile", "me.ichun.mods.sync.common.tileentity.TileEntityDualVertical");
         FMLInterModComms.sendMessage("AppliedEnergistics", "movabletile", "me.ichun.mods.sync.common.tileentity.TileEntityTreadmill");
-        FMLInterModComms.sendMessage("Waila", "register", "me.ichun.mods.sync.client.HUDHandlerSync.callbackRegister");
+        FMLInterModComms.sendMessage("Waila", "register", "me.ichun.mods.sync.client.HUDHandlerWaila.callbackRegister");
+        FMLInterModComms.sendFunctionMessage("theoneprobe", "getTheOneProbe", "me.ichun.mods.sync.client.HUDHandlerTheOneProbe");
 
         TREADMILL_ENTITY_HASH_MAP.put(EntityWolf.class, 4);
         TREADMILL_ENTITY_HASH_MAP.put(EntityPig.class, 2);

--- a/src/main/java/me/ichun/mods/sync/common/block/BlockDualVertical.java
+++ b/src/main/java/me/ichun/mods/sync/common/block/BlockDualVertical.java
@@ -314,7 +314,7 @@ public class BlockDualVertical extends BlockContainer {
                             //Mark this as in use
                             shellStorage.setPlayerName(player.getName());
                             shellStorage.occupied = true;
-                            notifyThisAndAbove(state, EnumType.STORAGE, pos, world, dualVertical.top);
+                            world.notifyBlockUpdate(pos, state, state, 3);
                         }
                     }
                 }

--- a/src/main/java/me/ichun/mods/sync/common/core/ProxyCommon.java
+++ b/src/main/java/me/ichun/mods/sync/common/core/ProxyCommon.java
@@ -37,15 +37,15 @@ public class ProxyCommon
 		Sync.itemShellConstructor = GameRegistry.register(new ItemShellBase(EnumType.CONSTRUCTOR).setRegistryName("sync", "item_shell_constructor").setUnlocalizedName("Sync_ShellConstructor").setCreativeTab(Sync.creativeTabSync));
 		Sync.itemShellStorage = GameRegistry.register(new ItemShellBase(EnumType.STORAGE).setRegistryName("sync", "item_shell_storage").setUnlocalizedName("Sync_ShellStorage").setCreativeTab(Sync.creativeTabSync));
 		Sync.itemTreadmill = GameRegistry.register(new ItemTreadmill().setRegistryName("sync", "item_treadmill").setUnlocalizedName("Sync_Treadmill").setCreativeTab(Sync.creativeTabSync));
-		Sync.itemPlaceholder = GameRegistry.register((new ItemGeneric()).setRegistryName("sync", "item_placeholder").setUnlocalizedName("Sync_SyncCore").setCreativeTab(Sync.creativeTabSync));
+		Sync.itemSyncCore = GameRegistry.register((new ItemGeneric()).setRegistryName("sync", "item_placeholder").setUnlocalizedName("Sync_SyncCore").setCreativeTab(Sync.creativeTabSync));
 
 		GameRegistry.addRecipe(new ItemStack(Sync.itemShellConstructor, 1, 0),
-				"OCO", "GGG", "ORO", 'O', Blocks.OBSIDIAN, 'C', Sync.itemPlaceholder, 'G', Blocks.GLASS_PANE, 'R', Items.REDSTONE);
+				"OCO", "GGG", "ORO", 'O', Blocks.OBSIDIAN, 'C', Sync.itemSyncCore, 'G', Blocks.GLASS_PANE, 'R', Items.REDSTONE);
 
-		GameRegistry.addRecipe(new ItemStack(Sync.itemShellStorage, 1, 1),
-				"OCO", "GIG", "OPO", 'O', Blocks.OBSIDIAN, 'C', Sync.itemPlaceholder, 'G', Blocks.GLASS_PANE, 'R', Items.REDSTONE, 'I', Blocks.IRON_BLOCK, 'P', Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE);
+		GameRegistry.addRecipe(new ItemStack(Sync.itemShellStorage, 1, 0),
+				"OCO", "GIG", "OPO", 'O', Blocks.OBSIDIAN, 'C', Sync.itemSyncCore, 'G', Blocks.GLASS_PANE, 'R', Items.REDSTONE, 'I', Blocks.IRON_BLOCK, 'P', Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE);
 
-		GameRegistry.addRecipe(new ItemStack(Sync.itemTreadmill, 1, 2),
+		GameRegistry.addRecipe(new ItemStack(Sync.itemTreadmill, 1, 0),
 				"  D", "CCI", "OOR", 'O', Blocks.OBSIDIAN, 'C', new ItemStack(Blocks.CARPET, 1, 15), 'I', Blocks.IRON_BARS, 'D', Blocks.DAYLIGHT_DETECTOR, 'R', Items.REDSTONE);
 
 		GameRegistry.registerTileEntity(TileEntityShellConstructor.class, "Sync_TEShellConstructor");

--- a/src/main/java/me/ichun/mods/sync/common/creativetab/CreativeTabSync.java
+++ b/src/main/java/me/ichun/mods/sync/common/creativetab/CreativeTabSync.java
@@ -18,6 +18,6 @@ public class CreativeTabSync extends CreativeTabs
 	@Override
     public Item getTabIconItem()
 	{
-		return Sync.itemPlaceholder;
+		return Sync.itemSyncCore;
 	}
 }

--- a/src/main/java/me/ichun/mods/sync/common/packet/PacketSyncRequest.java
+++ b/src/main/java/me/ichun/mods/sync/common/packet/PacketSyncRequest.java
@@ -2,6 +2,7 @@ package me.ichun.mods.sync.common.packet;
 
 import me.ichun.mods.ichunutil.common.core.network.AbstractPacket;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.relauncher.Side;
 import io.netty.buffer.ByteBuf;
@@ -138,10 +139,10 @@ public class PacketSyncRequest extends AbstractPacket
                         ss.setPlayerNBT(tag);
 
                         IBlockState state = worldOri.getBlockState(ss.getPos());
-                        IBlockState state1 = worldOri.getBlockState(ss.getPos().add(0, 1, 0));
+                        IBlockState state1 = worldOri.getBlockState(ss.getPos().offset(EnumFacing.UP));
 
                         worldOri.notifyBlockUpdate(ss.getPos(), state, state, 3);
-                        worldOri.notifyBlockUpdate(ss.getPos().add(0, 1, 0), state1, state1, 3);
+                        worldOri.notifyBlockUpdate(ss.getPos().offset(EnumFacing.UP), state1, state1, 3);
                     }
 
                     Sync.channel.sendTo(new PacketZoomCamera(xCoord, yCoord, zCoord, dimID, originShell.face, false, false), player);

--- a/src/main/java/me/ichun/mods/sync/common/tileentity/TileEntityDualVertical.java
+++ b/src/main/java/me/ichun/mods/sync/common/tileentity/TileEntityDualVertical.java
@@ -28,13 +28,10 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.GameType;
 import net.minecraft.world.WorldServer;
-import net.minecraftforge.common.UsernameCache;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-
-import java.util.UUID;
 
 //@Optional.Interface(iface = "cofh.api.energy.IEnergyHandler", modid = "CoFHCore")
 public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> extends TileEntity implements ITickable
@@ -338,7 +335,7 @@ public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> e
         tag.setInteger("face", face.getHorizontalIndex());
         tag.setBoolean("vacating", vacating);
         tag.setBoolean("isHomeUnit", isHomeUnit);
-        tag.setString("playerUUID", canSavePlayer > 0 || playerName.equals("") ? "" : EntityPlayer.getUUID(EntityHelper.getGameProfile(playerName)).toString());
+        tag.setString("playerName", canSavePlayer > 0 ? "" : playerName);
         tag.setString("name", name);
         tag.setTag("playerNBT", canSavePlayer > 0 ? new NBTTagCompound() : playerNBT);
         tag.setInteger("rfIntake", rfIntake);
@@ -353,13 +350,7 @@ public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> e
         face = EnumFacing.getHorizontal(tag.getInteger("face"));
         vacating = tag.getBoolean("vacating");
         isHomeUnit = tag.getBoolean("isHomeUnit");
-        if (tag.hasKey("playerName")) { //legacy tag, replaced by UUID
-            playerName = tag.getString("playerName");
-            tag.removeTag("playerName");
-        } else { //UUID tag should be present
-            String uuid = tag.getString("playerUUID");
-            playerName = uuid.equals("") ? "" : UsernameCache.getLastKnownUsername(UUID.fromString(uuid));
-        }
+        playerName = tag.getString("playerName");
         name = tag.getString("name");
         playerNBT = tag.getCompoundTag("playerNBT");
         rfIntake = tag.getInteger("rfIntake");

--- a/src/main/java/me/ichun/mods/sync/common/tileentity/TileEntityDualVertical.java
+++ b/src/main/java/me/ichun/mods/sync/common/tileentity/TileEntityDualVertical.java
@@ -171,6 +171,9 @@ public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> e
                         //Clear active potion effects before syncing
                         player.clearActivePotions();
 
+                        //Make sure the player looses all item, prevents duplication of e.g soulbound item
+                        player.inventory.clear();
+
                         if (!getPlayerNBT().hasKey("Inventory")) {
                             //Copy data needed from player
                             NBTTagCompound tag = new NBTTagCompound();
@@ -188,7 +191,7 @@ public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> e
                             dummy.dimension = player.dimension;
                             dummy.setEntityId(player.getEntityId());
 
-                            this.world.getGameRules().setOrCreateGameRule("keepInventory", keepInv ? "true" : "false");
+                            this.world.getGameRules().setOrCreateGameRule("keepInventory", Boolean.toString(keepInv));
 
                             //Set data
                             dummy.writeToNBT(tag);

--- a/src/main/java/me/ichun/mods/sync/common/tileentity/TileEntityDualVertical.java
+++ b/src/main/java/me/ichun/mods/sync/common/tileentity/TileEntityDualVertical.java
@@ -28,10 +28,13 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.GameType;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.UsernameCache;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.UUID;
 
 //@Optional.Interface(iface = "cofh.api.energy.IEnergyHandler", modid = "CoFHCore")
 public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> extends TileEntity implements ITickable
@@ -335,7 +338,7 @@ public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> e
         tag.setInteger("face", face.getHorizontalIndex());
         tag.setBoolean("vacating", vacating);
         tag.setBoolean("isHomeUnit", isHomeUnit);
-        tag.setString("playerName", canSavePlayer > 0 ? "" : playerName);
+        tag.setString("playerUUID", canSavePlayer > 0 || playerName.equals("") ? "" : EntityPlayer.getUUID(EntityHelper.getGameProfile(playerName)).toString());
         tag.setString("name", name);
         tag.setTag("playerNBT", canSavePlayer > 0 ? new NBTTagCompound() : playerNBT);
         tag.setInteger("rfIntake", rfIntake);
@@ -350,7 +353,13 @@ public abstract class TileEntityDualVertical<T extends TileEntityDualVertical> e
         face = EnumFacing.getHorizontal(tag.getInteger("face"));
         vacating = tag.getBoolean("vacating");
         isHomeUnit = tag.getBoolean("isHomeUnit");
-        playerName = tag.getString("playerName");
+        if (tag.hasKey("playerName")) { //legacy tag, replaced by UUID
+            playerName = tag.getString("playerName");
+            tag.removeTag("playerName");
+        } else { //UUID tag should be present
+            String uuid = tag.getString("playerUUID");
+            playerName = uuid.equals("") ? "" : UsernameCache.getLastKnownUsername(UUID.fromString(uuid));
+        }
         name = tag.getString("name");
         playerNBT = tag.getCompoundTag("playerNBT");
         rfIntake = tag.getInteger("rfIntake");


### PR DESCRIPTION
Rename itemPlaceholder to itemSyncCore in code, removed debug methods and fixed possible item dupe bug (#185). This also adds support for The One Probe, it's much more common in modpacks that are 1.10+ then WAILA. Of course, WAILA is still supported. Last but not least it fixes a derp with VertexBuffers that causes a crash.